### PR TITLE
fixed USE_POPCNT check in util.h

### DIFF
--- a/util.h
+++ b/util.h
@@ -29,7 +29,7 @@ public:
 inline int popcount(uint64_t b)
 {
 
-#ifndef USE_POPCNT
+#ifdef USE_POPCNT
 
     extern uint8_t PopCnt16[1 << 16];
     union {


### PR DESCRIPTION
There was faulty USE_POPCNT check which caused build failures on linux.